### PR TITLE
Improve performance and generalize supported block sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ nalgebra = "0.33.2"
 rustfft = "6.2.0"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib","lib"]
 name = "triforce"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ LIBDIR ?= $(PREFIX)/lib64
 default:
 	cargo build --release
 
+performance-test:
+	cargo build --release --example performance_test
+	hyperfine -w 3 -- 'target/release/examples/performance_test 600'
+
 install:
 	install -dDm0755 $(DESTDIR)/$(LIBDIR)/lv2/triforce.lv2/
 	install -pm0755 target/release/libtriforce.so $(DESTDIR)/$(LIBDIR)/lv2/triforce.lv2/triforce.so

--- a/examples/performance_test.rs
+++ b/examples/performance_test.rs
@@ -1,0 +1,24 @@
+use triforce;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let seconds : f32 = if args.len() < 2 { 60.0 } else {
+        match args[1].parse() {
+            Ok(x) => x,
+            Err(_) => {
+                panic!("Usage: perf_test <duration>\n\
+                        Simulate processing <duration> seconds of microphone input \
+                        (default to 60 seconds).")
+            }
+        }
+    };
+    let sample_rate = 48000.0;
+    let mut inst = triforce::Triforce::with_sample_rate(48000.0);
+    let i1 : Vec<f32> = (0..1024).map(|x| (x as f32) / 1024.0).collect();
+    let i2 : Vec<f32> = (0..1024).map(|x| ((x as f32) + 10.0) / 1024.0).collect();
+    let i3 : Vec<f32> = (0..1024).map(|x| ((x as f32) - 10.0) / 1024.0).collect();
+    let mut out : Vec<f32> = vec![0.0; 1024];
+    for _ in 0..(sample_rate * seconds / 1024.0) as i32 {
+        inst.process_slice(&i1, &i2, &i3, &mut out, 100.0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ impl Plugin for Triforce {
             analytic_signal(*ports.in_3),
         ];
         let num_samples = inputs[0].len();
-        if num_samples < 1023 {
+        if num_samples < 1024 {
             return;
         }
 
@@ -226,13 +226,13 @@ impl Plugin for Triforce {
         // the transitions.
         if self.samples_since_last_update as f32 >= (*ports.t_win / 1000.0) * self.sample_rate {
             self.samples_since_last_update = 0;
-            self.covar_window[0].extend_from_slice(&inputs[0][0..767]);
-            self.covar_window[1].extend_from_slice(&inputs[1][0..767]);
-            self.covar_window[2].extend_from_slice(&inputs[2][0..767]);
+            self.covar_window[0].extend_from_slice(&inputs[0][0..768]);
+            self.covar_window[1].extend_from_slice(&inputs[1][0..768]);
+            self.covar_window[2].extend_from_slice(&inputs[2][0..768]);
             self.covar = covariance(&self.covar_window);
-            self.covar_window[0] = inputs[0][768..1023].to_vec();
-            self.covar_window[1] = inputs[1][768..1023].to_vec();
-            self.covar_window[2] = inputs[2][768..1023].to_vec();
+            self.covar_window[0] = inputs[0][768..1024].to_vec();
+            self.covar_window[1] = inputs[1][768..1024].to_vec();
+            self.covar_window[2] = inputs[2][768..1024].to_vec();
         }
         else {
             self.samples_since_last_update += num_samples as u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,8 @@
  */
 
 use std::f32::consts::PI;
-use std::time::SystemTime;
-
 use lv2::prelude::*;
-
 use nalgebra::{linalg::SVD, ComplexField, DMatrix, DVector, Vector3};
-
 use rustfft::{num_complex::Complex, num_traits::Zero, FftPlanner};
 
 const C: f32 = 343.00; /* m*s^-1 */
@@ -171,7 +167,8 @@ struct Triforce {
     hangle_curr: f32,
     vangle_curr: f32,
     freq_curr: f32,
-    last_update: SystemTime,
+    sample_rate: f32,
+    samples_since_last_update: u32,
     covar_window: Vec<Vec<Complex<f32>>>,
     steering_vector: DVector<Complex<f32>>,
     covar: DMatrix<Complex<f32>>,
@@ -188,12 +185,13 @@ impl Plugin for Triforce {
     type InitFeatures = ();
     type AudioFeatures = ();
 
-    fn new(_info: &PluginInfo, _features: &mut ()) -> Option<Self> {
+    fn new(info: &PluginInfo, _features: &mut ()) -> Option<Self> {
         Some(Self {
             hangle_curr: 0f32,
             vangle_curr: 0f32,
             freq_curr: 1000f32,
-            last_update: SystemTime::now(),
+            samples_since_last_update: u32::max_value(),
+            sample_rate: info.sample_rate() as f32,
             covar_window: vec![
                 vec![Complex::new(0f32, 0f32); 256],
                 vec![Complex::new(0f32, 0f32); 256],
@@ -226,15 +224,18 @@ impl Plugin for Triforce {
 
         // Update the covariance matrix. We use an overlapping window to smooth over
         // the transitions.
-        if self.last_update.elapsed().unwrap().as_millis() > *ports.t_win as u128 {
+        if self.samples_since_last_update as f32 >= (*ports.t_win / 1000.0) * self.sample_rate {
+            self.samples_since_last_update = 0;
             self.covar_window[0].extend_from_slice(&inputs[0][0..767]);
             self.covar_window[1].extend_from_slice(&inputs[1][0..767]);
             self.covar_window[2].extend_from_slice(&inputs[2][0..767]);
             self.covar = covariance(&self.covar_window);
-            self.last_update = SystemTime::now();
             self.covar_window[0] = inputs[0][768..1023].to_vec();
             self.covar_window[1] = inputs[1][768..1023].to_vec();
             self.covar_window[2] = inputs[2][768..1023].to_vec();
+        }
+        else {
+            self.samples_since_last_update += num_samples as u32;
         }
 
         // Get the MVDR weights

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 
 use std::f32::consts::PI;
 use lv2::prelude::*;
-use nalgebra::{linalg::SVD, ComplexField, DMatrix, DVector, Vector3};
+use nalgebra::{linalg::SVD, ComplexField, Matrix3, Vector3};
 use rustfft::{num_complex::Complex, num_traits::Zero, FftPlanner};
 use std::sync::Mutex;
 
@@ -63,7 +63,7 @@ fn analytic_signal(planner: &mut FftPlanner<f32>, signal: &[f32]) -> Vec<Complex
 /// The steering vector is a representation of the phase delays at each microphone.
 /// It is calculated by taking the dot product of the array geometry matrix and the
 /// unit vector of the direction of arrival.
-fn steering_vec(theta: f32, phi: f32, f: f32, elems: [ElemDistance; 3]) -> DVector<Complex<f32>> {
+fn steering_vec(theta: f32, phi: f32, f: f32, elems: [ElemDistance; 3]) -> Vector3<Complex<f32>> {
     // Mic positions are relative to Left/Top to preserve x/y axis semantics
     let mic_positions: Vec<Vector3<f32>> =
         elems.iter().map(|e| Vector3::new(e.x, e.y, 0f32)).collect();
@@ -76,7 +76,7 @@ fn steering_vec(theta: f32, phi: f32, f: f32, elems: [ElemDistance; 3]) -> DVect
 
     // Calculate the steering vector by taking the array geometry, speed of sound,
     // and DOA unit vector
-    let mut steering_vector = DVector::from_element(mic_positions.len(), Complex::new(0f32, 0f32));
+    let mut steering_vector = Vector3::from_element(Complex::new(0f32, 0f32));
 
     for (i, mic_pos) in mic_positions.iter().enumerate() {
         let delay = mic_pos.dot(&u_dir) / C;
@@ -89,22 +89,21 @@ fn steering_vec(theta: f32, phi: f32, f: f32, elems: [ElemDistance; 3]) -> DVect
 
 /// There's nothing special about this, it's just a covariance matrix. It is always
 /// square.
-fn covariance(signals: &Vec<Vec<Complex<f32>>>) -> DMatrix<Complex<f32>> {
-    let n_mics = signals.len();
+fn covariance(signals: &[Vec<Complex<f32>>; 3]) -> Matrix3<Complex<f32>> {
     let n_samples = signals[0].len();
 
-    let mut covar = DMatrix::zeros(n_mics, n_mics);
+    let mut covar = Matrix3::zeros();
 
     for t in 0..n_samples {
-        let discrete: DVector<Complex<f32>> =
-            DVector::from_iterator(n_mics, signals.iter().map(|s| s[t]));
+        let discrete: Vector3<Complex<f32>> =
+            Vector3::new(signals[0][t], signals[1][t], signals[2][t]);
         covar += &discrete * discrete.adjoint();
     }
 
     // Our samples are shit, so we can't get a very nice covariance matrix.
     // Regularise the shit covariance matrix by introducing a constant value
     // across the identity
-    let reg = DMatrix::identity(covar.nrows(), covar.ncols())
+    let reg = Matrix3::identity()
         .map(|x: f32| Complex::new(x * 1e-4f32, 0f32));
 
     covar /= Complex::new(n_samples as f32, 0f32);
@@ -117,7 +116,7 @@ fn covariance(signals: &Vec<Vec<Complex<f32>>>) -> DMatrix<Complex<f32>> {
 /// w = (cov^-1 * sv) / (sv.adjoint() * (cov^-1 * sv)). Note that the denominator
 /// is the same as the conjugate-linear dot product of the steering vector and
 /// the numerator.
-fn mvdr_weights(cov: &DMatrix<Complex<f32>>, sv: &DVector<Complex<f32>>) -> DVector<Complex<f32>> {
+fn mvdr_weights(cov: &Matrix3<Complex<f32>>, sv: &Vector3<Complex<f32>>) -> Vector3<Complex<f32>> {
     // Since we have a numerically unstable covariance matrix, we can't take the
     // true inverse of it. Let's instead decompose it and take the pseudoinverse.
     let svd = SVD::new(cov.to_owned(), true, true);
@@ -169,12 +168,12 @@ pub struct Triforce {
     freq_curr: f32,
     sample_rate: f32,
     samples_since_last_update: u32,
-    covar_window: Vec<Vec<Complex<f32>>>,
-    steering_vector: DVector<Complex<f32>>,
-    covar: DMatrix<Complex<f32>>,
+    covar_window: [Vec<Complex<f32>>; 3],
+    steering_vector: Vector3<Complex<f32>>,
+    covar: Matrix3<Complex<f32>>,
     array_geom: [ElemDistance; 3],
     planner: Mutex<FftPlanner<f32>>,
-    weights: DVector<Complex<f32>>,
+    weights: Vector3<Complex<f32>>,
 }
 
 trait Beamformer: Plugin {
@@ -190,7 +189,7 @@ impl Triforce {
             freq_curr: 1000f32,
             samples_since_last_update: u32::max_value(),
             sample_rate,
-            covar_window: vec![
+            covar_window: [
                 vec![Complex::new(0f32, 0f32); 256],
                 vec![Complex::new(0f32, 0f32); 256],
                 vec![Complex::new(0f32, 0f32); 256],
@@ -202,9 +201,9 @@ impl Triforce {
                 1000f32,
                 [ElemDistance { x: 0f32, y: 0f32 }; 3],
             ),
-            covar: DMatrix::zeros(3, 3),
+            covar: Matrix3::zeros(),
             planner: Mutex::new(FftPlanner::new()),
-            weights: DVector::zeros(3),
+            weights: Vector3::zeros(),
         }
     }
 
@@ -245,10 +244,8 @@ impl Triforce {
         let mut out = vec![Complex::zero(); num_samples];
 
         for t in 0..num_samples {
-            let discrete: DVector<Complex<f32>> = DVector::from_iterator(
-                3, // number of mics
-                inputs.iter().map(|s| s[t]),
-            );
+            let discrete: Vector3<Complex<f32>> =
+                Vector3::new(inputs[0][t], inputs[1][t], inputs[2][t]);
 
             // Conjugate-linear dot product
             out[t] = self.weights.dotc(&discrete);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 
 use std::f32::consts::PI;
 use lv2::prelude::*;
-use nalgebra::{linalg::SVD, ComplexField, Matrix3, Vector3};
+use nalgebra::{linalg::SVD, Matrix3, Vector3};
 use rustfft::{num_complex::Complex, num_traits::Zero, FftPlanner};
 use std::sync::Mutex;
 
@@ -240,29 +240,26 @@ impl Triforce {
 
         // Get the MVDR weights
 
-        // Now we can finally do the beamforming
-        let mut out = vec![Complex::zero(); num_samples];
-
         for t in 0..num_samples {
             let discrete: Vector3<Complex<f32>> =
                 Vector3::new(inputs[0][t], inputs[1][t], inputs[2][t]);
 
-            // Conjugate-linear dot product
-            out[t] = self.weights.dotc(&discrete);
+            let out =
+                // Conjugate-linear dot product
+                self.weights.dotc(&discrete)
+                // Now we need to revert the Hilbert transform and output the signal
+                .re;
+
+            // Do all of our NFP and clamping here
+            let out =
+                if out.is_finite() && !out.is_nan() {
+                    out.clamp(-10f32, 10f32)
+                } else {
+                    0f32
+                };
+
+            output[t] = out;
         }
-
-        // Now we need to revert the Hilbert transform and output the signal
-        let re: Vec<f32> = out.iter().map(|z| z.re).collect();
-
-        // Do all of our NFP and clamping here
-        for (real, output) in Iterator::zip(re.iter(), output.iter_mut()) {
-            if real.is_finite() && !real.is_nan() {
-                *output = real.clamp(-10f32, 10f32);
-            } else {
-                *output = 0f32;
-            }
-        }
-
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::f32::consts::PI;
 use lv2::prelude::*;
 use nalgebra::{linalg::SVD, ComplexField, DMatrix, DVector, Vector3};
 use rustfft::{num_complex::Complex, num_traits::Zero, FftPlanner};
+use std::sync::Mutex;
 
 const C: f32 = 343.00; /* m*s^-1 */
 
@@ -27,7 +28,7 @@ struct ElemDistance {
 /// Perform a Hilbert transform on a slice of f32s to give us the analytic signal of
 /// our input sample buffer. This is necessary to extract phase information from the
 /// signal, and to make matrix operations a bit easier.
-fn analytic_signal(signal: &[f32]) -> Vec<Complex<f32>> {
+fn analytic_signal(planner: &mut FftPlanner<f32>, signal: &[f32]) -> Vec<Complex<f32>> {
     let len: usize = signal.len();
 
     // Convert each real sample into a complex sample
@@ -35,7 +36,6 @@ fn analytic_signal(signal: &[f32]) -> Vec<Complex<f32>> {
         signal.iter().map(|&x| Complex::new(x, 0.0)).collect();
 
     // Set up the fft and inverse fft
-    let mut planner = FftPlanner::new();
     let fft = planner.plan_fft_forward(len);
     let ifft = planner.plan_fft_inverse(len);
 
@@ -173,6 +173,7 @@ pub struct Triforce {
     steering_vector: DVector<Complex<f32>>,
     covar: DMatrix<Complex<f32>>,
     array_geom: [ElemDistance; 3],
+    planner: Mutex<FftPlanner<f32>>,
 }
 
 trait Beamformer: Plugin {
@@ -201,17 +202,21 @@ impl Triforce {
                 [ElemDistance { x: 0f32, y: 0f32 }; 3],
             ),
             covar: DMatrix::zeros(3, 3),
+            planner: Mutex::new(FftPlanner::new()),
         }
     }
 
     pub fn process_slice(&mut self, mic1: &[f32], mic2: &[f32], mic3: &[f32], output: &mut [f32], t_win: f32) {
 
         // Steering vector is relative to Left/Top mic
-        let inputs = vec![
-            analytic_signal(mic1),
-            analytic_signal(mic2),
-            analytic_signal(mic3),
-        ];
+        let inputs = {
+            let mut planner = self.planner.lock().unwrap();
+            vec![
+                analytic_signal(&mut planner, mic1),
+                analytic_signal(&mut planner, mic2),
+                analytic_signal(&mut planner, mic3),
+            ]
+        };
 
         let num_samples = inputs[0].len();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ fn mvdr_weights(cov: &DMatrix<Complex<f32>>, sv: &DVector<Complex<f32>>) -> DVec
  *      t_win: covariance matrix time window
  */
 #[derive(PortCollection)]
-struct Ports {
+pub struct Ports {
     in_1: InputPort<Audio>,
     in_2: InputPort<Audio>,
     in_3: InputPort<Audio>,
@@ -163,7 +163,7 @@ struct Ports {
  * Plugin state
  */
 #[uri("https://chadmed.au/triforce")]
-struct Triforce {
+pub struct Triforce {
     hangle_curr: f32,
     vangle_curr: f32,
     freq_curr: f32,
@@ -181,7 +181,30 @@ trait Beamformer: Plugin {
 
 impl Triforce {
 
-    fn process_slice(&mut self, mic1: &[f32], mic2: &[f32], mic3: &[f32], output: &mut [f32], t_win: f32) {
+    pub fn with_sample_rate(sample_rate: f32) -> Self {
+        Self {
+            hangle_curr: 0f32,
+            vangle_curr: 0f32,
+            freq_curr: 1000f32,
+            samples_since_last_update: u32::max_value(),
+            sample_rate,
+            covar_window: vec![
+                vec![Complex::new(0f32, 0f32); 256],
+                vec![Complex::new(0f32, 0f32); 256],
+                vec![Complex::new(0f32, 0f32); 256],
+            ],
+            array_geom: [ElemDistance { x: 0f32, y: 0f32 }; 3],
+            steering_vector: steering_vec(
+                90f32.to_radians(),
+                45f32.to_radians(),
+                1000f32,
+                [ElemDistance { x: 0f32, y: 0f32 }; 3],
+            ),
+            covar: DMatrix::zeros(3, 3),
+        }
+    }
+
+    pub fn process_slice(&mut self, mic1: &[f32], mic2: &[f32], mic3: &[f32], output: &mut [f32], t_win: f32) {
 
         // Steering vector is relative to Left/Top mic
         let inputs = vec![
@@ -247,26 +270,7 @@ impl Plugin for Triforce {
     type AudioFeatures = ();
 
     fn new(info: &PluginInfo, _features: &mut ()) -> Option<Self> {
-        Some(Self {
-            hangle_curr: 0f32,
-            vangle_curr: 0f32,
-            freq_curr: 1000f32,
-            samples_since_last_update: u32::max_value(),
-            sample_rate: info.sample_rate() as f32,
-            covar_window: vec![
-                vec![Complex::new(0f32, 0f32); 256],
-                vec![Complex::new(0f32, 0f32); 256],
-                vec![Complex::new(0f32, 0f32); 256],
-            ],
-            array_geom: [ElemDistance { x: 0f32, y: 0f32 }; 3],
-            steering_vector: steering_vec(
-                90f32.to_radians(),
-                45f32.to_radians(),
-                1000f32,
-                [ElemDistance { x: 0f32, y: 0f32 }; 3],
-            ),
-            covar: DMatrix::zeros(3, 3),
-        })
+        Some(Self::with_sample_rate(info.sample_rate() as f32))
     }
 
     fn run(&mut self, ports: &mut Ports, _features: &mut (), samples: u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,52 +179,22 @@ trait Beamformer: Plugin {
     fn update_params(&mut self, ports: &mut Ports);
 }
 
-impl Plugin for Triforce {
-    type Ports = Ports;
+impl Triforce {
 
-    type InitFeatures = ();
-    type AudioFeatures = ();
-
-    fn new(info: &PluginInfo, _features: &mut ()) -> Option<Self> {
-        Some(Self {
-            hangle_curr: 0f32,
-            vangle_curr: 0f32,
-            freq_curr: 1000f32,
-            samples_since_last_update: u32::max_value(),
-            sample_rate: info.sample_rate() as f32,
-            covar_window: vec![
-                vec![Complex::new(0f32, 0f32); 256],
-                vec![Complex::new(0f32, 0f32); 256],
-                vec![Complex::new(0f32, 0f32); 256],
-            ],
-            array_geom: [ElemDistance { x: 0f32, y: 0f32 }; 3],
-            steering_vector: steering_vec(
-                90f32.to_radians(),
-                45f32.to_radians(),
-                1000f32,
-                [ElemDistance { x: 0f32, y: 0f32 }; 3],
-            ),
-            covar: DMatrix::zeros(3, 3),
-        })
-    }
-
-    fn run(&mut self, ports: &mut Ports, _features: &mut (), _: u32) {
-        Beamformer::update_params(self, ports);
+    fn process_slice(&mut self, mic1: &[f32], mic2: &[f32], mic3: &[f32], output: &mut [f32], t_win: f32) {
 
         // Steering vector is relative to Left/Top mic
         let inputs = vec![
-            analytic_signal(*ports.in_1),
-            analytic_signal(*ports.in_2),
-            analytic_signal(*ports.in_3),
+            analytic_signal(mic1),
+            analytic_signal(mic2),
+            analytic_signal(mic3),
         ];
+
         let num_samples = inputs[0].len();
-        if num_samples < 1024 {
-            return;
-        }
 
         // Update the covariance matrix. We use an overlapping window to smooth over
         // the transitions.
-        if self.samples_since_last_update as f32 >= (*ports.t_win / 1000.0) * self.sample_rate {
+        if self.samples_since_last_update as f32 >= (t_win / 1000.0) * self.sample_rate {
             self.samples_since_last_update = 0;
             self.covar_window[0].extend_from_slice(&inputs[0][0..768]);
             self.covar_window[1].extend_from_slice(&inputs[1][0..768]);
@@ -258,13 +228,53 @@ impl Plugin for Triforce {
         let re: Vec<f32> = out.iter().map(|z| z.re).collect();
 
         // Do all of our NFP and clamping here
-        for (real, output) in Iterator::zip(re.iter(), ports.out.iter_mut()) {
+        for (real, output) in Iterator::zip(re.iter(), output.iter_mut()) {
             if real.is_finite() && !real.is_nan() {
                 *output = real.clamp(-10f32, 10f32);
             } else {
                 *output = 0f32;
             }
         }
+
+    }
+}
+
+
+impl Plugin for Triforce {
+    type Ports = Ports;
+
+    type InitFeatures = ();
+    type AudioFeatures = ();
+
+    fn new(info: &PluginInfo, _features: &mut ()) -> Option<Self> {
+        Some(Self {
+            hangle_curr: 0f32,
+            vangle_curr: 0f32,
+            freq_curr: 1000f32,
+            samples_since_last_update: u32::max_value(),
+            sample_rate: info.sample_rate() as f32,
+            covar_window: vec![
+                vec![Complex::new(0f32, 0f32); 256],
+                vec![Complex::new(0f32, 0f32); 256],
+                vec![Complex::new(0f32, 0f32); 256],
+            ],
+            array_geom: [ElemDistance { x: 0f32, y: 0f32 }; 3],
+            steering_vector: steering_vec(
+                90f32.to_radians(),
+                45f32.to_radians(),
+                1000f32,
+                [ElemDistance { x: 0f32, y: 0f32 }; 3],
+            ),
+            covar: DMatrix::zeros(3, 3),
+        })
+    }
+
+    fn run(&mut self, ports: &mut Ports, _features: &mut (), samples: u32) {
+        Beamformer::update_params(self, ports);
+        if samples < 1024 {
+            return;
+        }
+        self.process_slice(&ports.in_1, &ports.in_2, &ports.in_3, &mut ports.out, *ports.t_win);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,24 @@ impl Plugin for Triforce {
         if samples < 1024 {
             return;
         }
-        self.process_slice(&ports.in_1, &ports.in_2, &ports.in_3, &mut ports.out, *ports.t_win);
+
+        let mut i : usize = 0;
+        while i + 2048 <= samples as usize {
+            let j : usize = i + 1024;
+            self.process_slice(&ports.in_1[i..j],
+                               &ports.in_2[i..j],
+                               &ports.in_3[i..j],
+                               &mut ports.out[i..j],
+                               *ports.t_win);
+            i += 1024;
+        }
+
+        let j = samples as usize;
+        self.process_slice(&ports.in_1[i..j],
+                           &ports.in_2[i..j],
+                           &ports.in_3[i..j],
+                           &mut ports.out[i..j],
+                           *ports.t_win);
     }
 }
 


### PR DESCRIPTION
# Improving performance 

This PR starts by adding a `performance-test` target to the Makefile that processes 10 minutes of dummy contents and measure the time taken using `hyperfine`.

The next patches implement a bunch of optimization on top of that code (that should not change the output):

```
Initial code

  Time (mean ± σ):      2.139 s ±  0.029 s    [User: 2.133 s, System: 0.001 s]
  Range (min … max):    2.112 s …  2.182 s    10 runs
 
Cache fft plans

  Time (mean ± σ):     848.4 ms ±  30.1 ms    [User: 845.2 ms, System: 0.6 ms]
  Range (min … max):   811.8 ms … 877.9 ms    10 runs
 
Cache mvdr weights

  Time (mean ± σ):     664.7 ms ±  31.5 ms    [User: 661.9 ms, System: 0.8 ms]
  Range (min … max):   619.0 ms … 686.1 ms    10 runs
 
Use static vectors

  Time (mean ± σ):     495.2 ms ±  34.0 ms    [User: 492.7 ms, System: 1.0 ms]
  Range (min … max):   450.3 ms … 522.4 ms    10 runs
 
Use one less intermediate vector

  Time (mean ± σ):     490.4 ms ±  34.8 ms    [User: 488.5 ms, System: 0.5 ms]
  Range (min … max):   451.0 ms … 524.9 ms    10 runs
```

So processing is roughly 4x times faster after the optimizations.
Now 80% of the time is spent in the analytic transform and, more specifically, 65% in the FFT.

# Support other block sizes

The existing code was assuming blocks of 1024 samples (unfortunately, on my system, a fresh install of fedora 42 with gnome, the default block size was 256, so the microphone was broken).
Now it works with any size, while trying to compute the same coveriance window as if the blocks were 1024-sized:

- Larger blocks are split into chunks of size 1024 (except for the last chunk which has a size between 1024 and 2047); the result should be audibly identical
- Smaller blocks are accumulated until reaching an appropriately sized window. The result can still be different since the analytic transform is done blockwise on smaller blocks (it would be worth checking if an overlapping analytic transform improve the reconstruction).