### PR TITLE
Support block size less than 1024 as well as a few simplifications and cleanups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,12 @@ impl Triforce {
             self.covar_window[1].extend_from_slice(&self.inputs[1][0..i]);
             self.covar_window[2].extend_from_slice(&self.inputs[2][0..i]);
             self.covar = covariance(&self.covar_window, self.covar_window[0].len());
-            self.covar_window[0] = self.inputs[0][i..buf_len].to_vec();
-            self.covar_window[1] = self.inputs[1][i..buf_len].to_vec();
-            self.covar_window[2] = self.inputs[2][i..buf_len].to_vec();
+            self.covar_window[0].clear();
+            self.covar_window[0].extend_from_slice(&self.inputs[0][i..buf_len]);
+            self.covar_window[1].clear();
+            self.covar_window[1].extend_from_slice(&self.inputs[1][i..buf_len]);
+            self.covar_window[2].clear();
+            self.covar_window[2].extend_from_slice(&self.inputs[2][i..buf_len]);
             self.weights = mvdr_weights(&self.covar, &self.steering_vector);
         } else {
             self.samples_since_last_update += buf_len;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@ use nalgebra::{linalg::SVD, Matrix3, Vector3};
 
 use rustfft::{num_complex::Complex, num_traits::Zero, FftPlanner};
 
-use std::sync::Mutex;
-
 const C: f32 = 343.00; /* m*s^-1 */
 
 /// The distance of a given element in the array from the zeroth
@@ -170,7 +168,7 @@ pub struct Triforce {
     steering_vector: Vector3<Complex<f32>>,
     covar: Matrix3<Complex<f32>>,
     array_geom: [ElemDistance; 3],
-    fft_planner: Mutex<FftPlanner<f32>>,
+    fft_planner: FftPlanner<f32>,
     weights: Vector3<Complex<f32>>,
 }
 
@@ -199,7 +197,7 @@ impl Triforce {
                 [ElemDistance { x: 0f32, y: 0f32 }; 3],
             ),
             covar: Matrix3::zeros(),
-            fft_planner: Mutex::new(FftPlanner::new()),
+            fft_planner: FftPlanner::new(),
             weights: Vector3::zeros(),
         }
     }
@@ -215,11 +213,10 @@ impl Triforce {
     ) {
         // Steering vector is relative to Left/Top mic
         let inputs = {
-            let mut planner = self.fft_planner.lock().unwrap();
             vec![
-                analytic_signal(&mut planner, mic1, buf_len),
-                analytic_signal(&mut planner, mic2, buf_len),
-                analytic_signal(&mut planner, mic3, buf_len),
+                analytic_signal(&mut self.fft_planner, mic1, buf_len),
+                analytic_signal(&mut self.fft_planner, mic2, buf_len),
+                analytic_signal(&mut self.fft_planner, mic3, buf_len),
             ]
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,9 @@ impl Triforce {
             self.covar_window[1].extend_from_slice(&self.inputs[1][0..i]);
             self.covar_window[2].extend_from_slice(&self.inputs[2][0..i]);
             self.covar = covariance(&self.covar_window, self.covar_window[0].len());
-            self.covar_window[0] = self.inputs[0][i + 1..buf_len].to_vec();
-            self.covar_window[1] = self.inputs[1][i + 1..buf_len].to_vec();
-            self.covar_window[2] = self.inputs[2][i + 1..buf_len].to_vec();
+            self.covar_window[0] = self.inputs[0][i..buf_len].to_vec();
+            self.covar_window[1] = self.inputs[1][i..buf_len].to_vec();
+            self.covar_window[2] = self.inputs[2][i..buf_len].to_vec();
             self.weights = mvdr_weights(&self.covar, &self.steering_vector);
         } else {
             self.samples_since_last_update += buf_len;


### PR DESCRIPTION
The main effect is to remove the check on block size to support arbitrary quantum.
The other changes are:
- Remove the use of Mutex; it was a left-over from an experiment in my previous PR and should have not made its way to the release, apologies (fortunately it is harmless).
- Remove memory allocations once reaching steady regime (do analytic transform and update covariance window in place). This increases performance by ~10%, though there was a lot of noise.