### PR TITLE
IIR-based analytic transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,15 +202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "primal-check"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
-dependencies = [
- "num-integer",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,21 +226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "rustfft"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f266ff9b0cfc79de11fd5af76a2bc672fe3ace10c96fa06456740fa70cb1ed49"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "primal-check",
- "strength_reduce",
- "transpose",
- "version_check",
-]
-
-[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,12 +246,6 @@ dependencies = [
  "paste",
  "wide",
 ]
-
-[[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
@@ -300,22 +270,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
-]
-
-[[package]]
 name = "triforce-lv2"
 version = "0.3.2"
 dependencies = [
  "lv2",
  "nalgebra",
- "rustfft",
+ "num-complex",
 ]
 
 [[package]]
@@ -349,12 +309,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wide"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ lto = "thin"
 [dependencies]
 lv2 = "0.6.0"
 nalgebra = "0.33.2"
-rustfft = "6.2.0"
+num-complex = "0.4"
 
 [lib]
 crate-type = ["cdylib","lib"]

--- a/examples/performance_test.rs
+++ b/examples/performance_test.rs
@@ -1,28 +1,38 @@
 use triforce;
 
+fn usage<T, A>(_: T) -> A {
+    panic!(
+        "Usage: perf_test <duration> <blocksize>\n\
+         Simulate processing <duration> seconds of microphone input \
+         (default to 60 seconds), \
+         using blocks of <blocksize> samples (defaults to 1024)."
+    )
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let seconds: f32 = if args.len() < 2 {
         60.0
     } else {
-        match args[1].parse() {
-            Ok(x) => x,
-            Err(_) => {
-                panic!(
-                    "Usage: perf_test <duration>\n\
-                        Simulate processing <duration> seconds of microphone input \
-                        (default to 60 seconds)."
-                )
-            }
-        }
+        args[1].parse().unwrap_or_else(usage)
+    };
+    let blocksize: usize = if args.len() < 3 {
+        1024
+    } else {
+        args[2].parse().unwrap_or_else(usage)
     };
     let sample_rate = 48000.0;
     let mut inst = triforce::Triforce::with_sample_rate(48000.0);
-    let i1: Vec<f32> = (0..1024).map(|x| (x as f32) / 1024.0).collect();
-    let i2: Vec<f32> = (0..1024).map(|x| ((x as f32) + 10.0) / 1024.0).collect();
-    let i3: Vec<f32> = (0..1024).map(|x| ((x as f32) - 10.0) / 1024.0).collect();
-    let mut out: Vec<f32> = vec![0.0; 1024];
-    for _ in 0..(sample_rate * seconds / 1024.0) as i32 {
-        inst.process_slice(&i1, &i2, &i3, &mut out, 100.0, i1.len());
+    let i1: Vec<f32> = (0..blocksize).map(|x| (x as f32) / 1024.0).collect();
+    let i2: Vec<f32> = (0..blocksize)
+        .map(|x| ((x as f32) + 10.0) / 1024.0)
+        .collect();
+    let i3: Vec<f32> = (0..blocksize)
+        .map(|x| ((x as f32) - 10.0) / 1024.0)
+        .collect();
+    let mut out: Vec<f32> = Vec::new();
+    out.resize(blocksize, 0.0);
+    for _ in 0..(sample_rate * seconds / blocksize as f32) as i32 {
+        inst.process_slice(&i1, &i2, &i3, &mut out, 100.0, blocksize);
     }
 }

--- a/src/hilbert_iir.rs
+++ b/src/hilbert_iir.rs
@@ -1,0 +1,182 @@
+/* Original implementation:
+ *   https://github.com/Signalsmith-Audio/hilbert-iir
+ *   Signalsmith's Hilbert IIR: A single-file, dependency-free Hilbert filter.
+ *   Copyright (c) 2024 Geraint Luff / Signalsmith Audio Ltd.
+ *   Released under 0BSD: BSD Zero Clause License
+ */
+
+use nalgebra::Complex;
+
+// Approximate Hilbert analytic transform with an IIR filter.
+// The filter uses a 12th-order IIR design with pre-calculated coefficients and
+// poles. To increase throughput, this translation is designed to work with
+// multiple channels simultaneously.
+
+const ORDER: usize = 12;
+
+/// Pre-calculated complex coefficients for the IIR filter.
+const COEFFS: [Complex<f32>; ORDER] = [
+    Complex::<f32>::new(-0.000224352093802, 0.00543499018201),
+    Complex::<f32>::new(0.010750055781500, -0.01738906856810),
+    Complex::<f32>::new(-0.045679587391700, 0.02291669314290),
+    Complex::<f32>::new(0.112825005820000, 0.00278413661237),
+    Complex::<f32>::new(-0.208067578452000, -0.10462895867500),
+    Complex::<f32>::new(0.287178375010000, 0.33619239719000),
+    Complex::<f32>::new(-0.254675294431000, -0.68303389965500),
+    Complex::<f32>::new(0.048108183502600, 0.95406158937400),
+    Complex::<f32>::new(0.227861357867000, -0.89127357456900),
+    Complex::<f32>::new(-0.365411839137000, 0.52508831727100),
+    Complex::<f32>::new(0.280729061131000, -0.15513120660600),
+    Complex::<f32>::new(-0.093506178772800, 0.00512245855404),
+];
+
+/// Pre-calculated complex poles for the IIR filter.
+const POLES: [Complex<f32>; ORDER] = [
+    Complex::<f32>::new(-0.00495335976478, 0.0092579876872),
+    Complex::<f32>::new(-0.01785949130200, 0.0273493725543),
+    Complex::<f32>::new(-0.04137143731550, 0.0744756910287),
+    Complex::<f32>::new(-0.08821484088850, 0.1783496774570),
+    Complex::<f32>::new(-0.17922965812000, 0.3960134022300),
+    Complex::<f32>::new(-0.33826180075300, 0.8292295333540),
+    Complex::<f32>::new(-0.55768869973200, 1.6129853832800),
+    Complex::<f32>::new(-0.73515773614800, 2.7998739868200),
+    Complex::<f32>::new(-0.71905738117200, 4.1639616612800),
+    Complex::<f32>::new(-0.51787102520900, 5.2972482680400),
+    Complex::<f32>::new(-0.28019746947100, 5.9959860238800),
+    Complex::<f32>::new(-0.08527513545310, 6.3048492377000),
+];
+
+/// Direct term for the IIR filter.
+const DIRECT: f32 = 0.000262057212648;
+
+// Performance note:
+// Internal structures separate the real and imaginary components using two
+// float arrays rather than an array of Complex<f32> as this offer more
+// opportunity for auto-vectorization.
+
+/// Structure representing the IIR filter with its coefficients and poles.
+/// The coefficients are computed once and shared across all channels.
+#[derive(Clone, Copy)]
+pub struct Filter {
+    coeffs_r: [f32; ORDER],
+    coeffs_i: [f32; ORDER],
+    poles_r: [f32; ORDER],
+    poles_i: [f32; ORDER],
+    direct: f32,
+}
+
+/// Structure representing the internal state of the filter for one channel.
+#[derive(Clone, Copy)]
+pub struct State {
+    real: [f32; ORDER],
+    imag: [f32; ORDER],
+}
+
+impl State {
+    /// Initial state for a channel.
+    pub const INITIAL: State = State {
+        real: [-1.0; ORDER],
+        imag: [0.0; ORDER],
+    };
+}
+
+impl Filter {
+    /// Initialize a filter with the given sample rate and passband gain.
+    /// Recommended settings: `Filter::new(48000.0, 2.0)`
+    pub fn new(sample_rate: f32, passband_gain: f32) -> Filter {
+        let freq_factor = f32::min(0.46, 20000.0 / sample_rate);
+        let mut result = Filter {
+            coeffs_r: [0.0; ORDER],
+            coeffs_i: [0.0; ORDER],
+            poles_r: [0.0; ORDER],
+            poles_i: [0.0; ORDER],
+            direct: 0.0,
+        };
+        result.direct = DIRECT * 2.0 * passband_gain * freq_factor;
+        for i in 0..ORDER {
+            let coeff = COEFFS[i] * freq_factor * passband_gain;
+            result.coeffs_r[i] = coeff.re;
+            result.coeffs_i[i] = coeff.im;
+            let pole = (POLES[i] * freq_factor).exp();
+            result.poles_r[i] = pole.re;
+            result.poles_i[i] = pole.im;
+        }
+        result
+    }
+
+    /// Process the input signal and produce the output signal for N channels.
+    pub fn process<const N: usize>(
+        &self,
+        state: &mut [State; N],
+        input: &[&[f32]; N],
+        output: &mut [&mut [Complex<f32>]; N],
+    ) {
+        if N == 0 {
+            return;
+        };
+        let samples = input[0].len();
+        for i in 0..samples {
+            let mut ra: [f32; N] = input.map(|x| x[i] * self.direct);
+            let mut ia: [f32; N] = [0f32; N];
+            for j in 0..ORDER {
+                let mut rv = [0f32; N];
+                let mut iv = [0f32; N];
+                for k in 0..N {
+                    rv[k] = state[k].real[j] * self.poles_r[j]
+                        - state[k].imag[j] * self.poles_i[j]
+                        + input[k][i] * self.coeffs_r[j];
+                    iv[k] = state[k].real[j] * self.poles_i[j]
+                        + state[k].imag[j] * self.poles_r[j]
+                        + input[k][i] * self.coeffs_i[j];
+                }
+                for k in 0..N {
+                    ra[k] += rv[k];
+                    ia[k] += iv[k];
+                    state[k].real[j] = rv[k];
+                    state[k].imag[j] = iv[k];
+                }
+            }
+            for k in 0..N {
+                output[k][i] = Complex::new(ra[k], ia[k]);
+            }
+        }
+    }
+
+    /// Process the input signal and produce separate real and imaginary output
+    /// signals for N channels.
+    #[allow(dead_code)]
+    pub fn process_split<const N: usize>(
+        &self,
+        state: &mut [State; N],
+        input: &[&[f32]; N],
+        real: &mut [&mut [f32]; N],
+        imag: &mut [&mut [f32]; N],
+    ) {
+        if N == 0 {
+            return;
+        };
+        let samples = input[0].len();
+        for i in 0..samples {
+            let mut ra: [f32; N] = input.map(|x| x[i] * self.direct);
+            let mut ia: [f32; N] = [0f32; N];
+            for j in 0..ORDER {
+                for k in 0..N {
+                    let r = state[k].real[j] * self.poles_r[j]
+                        - state[k].imag[j] * self.poles_i[j]
+                        + input[k][i] * self.coeffs_r[j];
+                    let i = state[k].real[j] * self.poles_i[j]
+                        + state[k].imag[j] * self.poles_r[j]
+                        + input[k][i] * self.coeffs_i[j];
+                    ra[k] += r;
+                    ia[k] += i;
+                    state[k].real[j] = r;
+                    state[k].imag[j] = i;
+                }
+            }
+            for k in 0..N {
+                real[k][i] = ra[k];
+                imag[k][i] = ia[k];
+            }
+        }
+    }
+}


### PR DESCRIPTION
This branch replaces the analytic transform by an IIR-based implementation (a performance-tuned reimplementation of https://github.com/Signalsmith-Audio/hilbert-iir in Rust).

According to `make performance-test` on a Macbook Air M2:
- FFT-based transform: 480ms to process 600 seconds (1250x realtime)
- IIR-based transform: 591ms to process 600 seconds (1015x realtime)

So it is slightly slower than the FFT transform, but it is insensitive to block-size and should, in theory, offer a better quality. I have not tried to measure the quality objectively (I have been using it for a few meetings and it was good enough :)).

If we decide to proceed with this implementation, it would be nice to notify Signalsmigh-Audio :).

Performance consideration: the code was designed with auto-vectorization in mind, rustc performs ok with it. However the same code compiled with `-ffast-math` was significantly faster (even faster than the highly-optimized FFT) without degrading the output, but this is not available in stable rust.